### PR TITLE
태스크 스케줄러 도입

### DIFF
--- a/backend/src/main/java/mouda/backend/bet/business/BetScheduler.java
+++ b/backend/src/main/java/mouda/backend/bet/business/BetScheduler.java
@@ -1,11 +1,15 @@
 package mouda.backend.bet.business;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import mouda.backend.bet.domain.Bet;
 import mouda.backend.bet.implement.BetFinder;
@@ -14,24 +18,33 @@ import mouda.backend.chat.domain.ChatRoomType;
 import mouda.backend.chat.implement.ChatRoomWriter;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class BetScheduler {
 
-	@Value("${bet.schedule}")
-	private String rate;
+	private static final ZoneOffset KST_OFFSET = ZoneOffset.ofHours(9);
 
 	private final BetFinder betFinder;
 	private final BetWriter betWriter;
+	private final TaskScheduler taskScheduler;
 	private final ChatRoomWriter chatRoomWriter;
 
 	@Scheduled(cron = "${bet.schedule}")
 	public void performScheduledTask() {
 		List<Bet> bets = betFinder.findAllDrawableBet();
 
-		bets.forEach(Bet::draw);
+	public void scheduleDraw(Bet bet, long betId) {
+		Instant startTime = bet.getBettingTime().toInstant(KST_OFFSET);
+		taskScheduler.schedule(() -> performScheduledTask(betId), startTime);
+	}
 
 		betWriter.saveAll(bets);
 
-		bets.forEach(bet -> chatRoomWriter.append(bet.getId(), bet.getDarakbangId(), ChatRoomType.BET));
+	private void performScheduledTask(long betId) {
+		Bet bet = betFinder.find(betId);
+		bet.draw();
+		betWriter.appendLoser(bet);
+
+		chatRoomWriter.append(bet.getId(), bet.getDarakbangId(), ChatRoomType.BET);
 	}
 }

--- a/backend/src/main/java/mouda/backend/bet/business/BetService.java
+++ b/backend/src/main/java/mouda/backend/bet/business/BetService.java
@@ -30,6 +30,7 @@ public class BetService {
 	private final BetSorter betSorter;
 	private final ChatRoomFinder chatRoomFinder;
 	private final ChatRoomWriter chatRoomWriter;
+	private final BetScheduler betScheduler;
 
 	@Transactional(readOnly = true)
 	public BetFindAllResponses findAllBets(long darakbangId) {
@@ -49,6 +50,8 @@ public class BetService {
 		Bet bet = betRequest.toBet(darakbangMember.getId());
 		long savedBetId = betWriter.save(darakbangId, bet);
 		betWriter.participate(darakbangId, savedBetId, darakbangMember);
+		
+		betScheduler.scheduleDraw(bet, savedBetId);
 
 		return savedBetId;
 	}

--- a/backend/src/main/java/mouda/backend/bet/domain/Bet.java
+++ b/backend/src/main/java/mouda/backend/bet/domain/Bet.java
@@ -1,5 +1,6 @@
 package mouda.backend.bet.domain;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Random;
 
@@ -67,5 +68,9 @@ public class Bet {
 
 	public boolean canNotParticipate() {
 		return hasLoser() || betDetails.pastBettingTime();
+	}
+
+	public LocalDateTime getBettingTime() {
+		return betDetails.getBettingTime();
 	}
 }

--- a/backend/src/main/java/mouda/backend/bet/domain/BetDetails.java
+++ b/backend/src/main/java/mouda/backend/bet/domain/BetDetails.java
@@ -1,6 +1,7 @@
 package mouda.backend.bet.domain;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +11,7 @@ public class BetDetails {
 
 	private final long id;
 	private final String title;
-	private final BettingTime bettingTime;
+	private final LocalDateTime bettingTime;
 	private final long moimerId;
 	private final Long loserId;
 
@@ -18,7 +19,7 @@ public class BetDetails {
 	public BetDetails(long id, String title, LocalDateTime bettingTime, long moimerId, Long loserId) {
 		this.id = id;
 		this.title = title;
-		this.bettingTime = new BettingTime(bettingTime);
+		this.bettingTime = bettingTime;
 		this.moimerId = moimerId;
 		this.loserId = loserId;
 	}
@@ -32,12 +33,8 @@ public class BetDetails {
 			.build();
 	}
 
-	public LocalDateTime getBettingTime() {
-		return bettingTime.getBettingTime();
-	}
-
 	public long timeDifferenceInMinutesWithNow() {
-		return bettingTime.timeDifferenceInMinutesWithNow();
+		return Math.abs(ChronoUnit.MINUTES.between(LocalDateTime.now(), this.bettingTime));
 	}
 
 	public boolean hasLoser() {
@@ -45,6 +42,6 @@ public class BetDetails {
 	}
 
 	public boolean pastBettingTime() {
-		return bettingTime.isPast();
+		return LocalDateTime.now().isAfter(bettingTime);
 	}
 }

--- a/backend/src/main/java/mouda/backend/bet/implement/BetFinder.java
+++ b/backend/src/main/java/mouda/backend/bet/implement/BetFinder.java
@@ -36,15 +36,22 @@ public class BetFinder {
 		return createBet(betEntity);
 	}
 
+	public Bet find(long betEntityId) {
+		BetEntity betEntity = betRepository.findById(betEntityId)
+			.orElseThrow(() -> new BetException(HttpStatus.NOT_FOUND, BetErrorMessage.BET_NOT_FOUND));
+
+		return createBet(betEntity);
+	}
+
 	public List<Bet> findAllByDarakbangId(long darakbangId) {
 		List<BetEntity> betEntities = betRepository.findAllByDarakbangId(darakbangId);
 
 		return createBets(betEntities);
 	}
 
-	public List<Bet> findAllDrawableBet() {
-		List<BetEntity> betEntities = betRepository.findAllByBettingTimeAndLoserDarakbangMemberIdIsNull(
-			LocalDateTime.now().withSecond(0).withNano(0));
+	public List<Bet> findAllScheduledBet() {
+		List<BetEntity> betEntities = betRepository.findAllByBettingTimeGreaterThanEqualAndLoserDarakbangMemberIdIsNull(
+			LocalDateTime.now());
 
 		return createBets(betEntities);
 	}

--- a/backend/src/main/java/mouda/backend/bet/implement/BetWriter.java
+++ b/backend/src/main/java/mouda/backend/bet/implement/BetWriter.java
@@ -37,6 +37,10 @@ public class BetWriter {
 		return betEntity.getId();
 	}
 
+	public void appendLoser(Bet bet) {
+		betRepository.save(BetEntity.from(bet));
+	}
+
 	public void participate(long darakbangId, long betId, DarakbangMember darakbangMember) {
 		Bet bet = betFinder.find(darakbangId, betId);
 		if (bet.canNotParticipate()) {

--- a/backend/src/main/java/mouda/backend/bet/infrastructure/BetRepository.java
+++ b/backend/src/main/java/mouda/backend/bet/infrastructure/BetRepository.java
@@ -9,10 +9,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import mouda.backend.bet.entity.BetEntity;
 
 public interface BetRepository extends JpaRepository<BetEntity, Long> {
-	
+
 	List<BetEntity> findAllByDarakbangId(long darakbangId);
 
 	Optional<BetEntity> findByIdAndDarakbangId(long darakbangId, long betEntityId);
 
-	List<BetEntity> findAllByBettingTimeAndLoserDarakbangMemberIdIsNull(LocalDateTime localDateTime);
+	List<BetEntity> findAllByBettingTimeGreaterThanEqualAndLoserDarakbangMemberIdIsNull(LocalDateTime localDateTime);
 }

--- a/backend/src/main/java/mouda/backend/common/config/TaskSchedulerConfig.java
+++ b/backend/src/main/java/mouda/backend/common/config/TaskSchedulerConfig.java
@@ -1,0 +1,17 @@
+package mouda.backend.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class TaskSchedulerConfig {
+
+	@Bean
+	public ThreadPoolTaskScheduler threadPoolTaskScheduler() {
+		ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+		threadPoolTaskScheduler.setPoolSize(3);
+		threadPoolTaskScheduler.setThreadNamePrefix("ThreadPoolBetScheduler");
+		return threadPoolTaskScheduler;
+	}
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,3 +25,4 @@ url:
 
 bet:
   schedule: "0 * * * * *" # 매분마다
+  master: false

--- a/backend/src/test/java/mouda/backend/bet/implement/BetFinderTest.java
+++ b/backend/src/test/java/mouda/backend/bet/implement/BetFinderTest.java
@@ -67,24 +67,26 @@ class BetFinderTest extends DarakbangSetUp {
 		assertThat(emptyBetDetails).hasSize(0);
 	}
 
-	@DisplayName("추첨 가능한 모든 안내면진다를 조회한다.")
+	@DisplayName("예약된 모든 안내면진다를 조회한다.")
 	@Test
 	void findAllDrawableBets() {
 		// given
 		long darakbangId = darakbang.getId();
-		BetEntity betEntity = BetEntityFixture.getBetEntity(darakbangId, darakbangAnna.getId());
+		BetEntity betEntity = BetEntityFixture.getBetEntity(darakbangId, darakbangAnna.getId(),
+			LocalDateTime.now().plusSeconds(10));
 		betRepository.save(betEntity);
 
 		long moudaDarakbangId = mouda.getId();
-		BetEntity betEntity2 = BetEntityFixture.getBetEntity(moudaDarakbangId, darakbangAnna.getId());
+		BetEntity betEntity2 = BetEntityFixture.getBetEntity(moudaDarakbangId, darakbangAnna.getId(),
+			LocalDateTime.now().plusMinutes(10));
 		betRepository.save(betEntity2);
 
 		BetEntity betEntity3 = BetEntityFixture.getBetEntity(moudaDarakbangId, darakbangAnna.getId(),
-			LocalDateTime.now().plusMinutes(10));
+			LocalDateTime.now().minusMinutes(1));
 		betRepository.save(betEntity3);
 
 		// when
-		List<Bet> bets = betFinder.findAllDrawableBet();
+		List<Bet> bets = betFinder.findAllScheduledBet();
 
 		//then
 		assertThat(bets).hasSize(2);

--- a/backend/src/test/java/mouda/backend/bet/infrastructure/BetRepositoryTest.java
+++ b/backend/src/test/java/mouda/backend/bet/infrastructure/BetRepositoryTest.java
@@ -30,7 +30,7 @@ class BetRepositoryTest {
 		betRepository.save(betEntity2);
 
 		// when
-		List<BetEntity> betEntities = betRepository.findAllByBettingTimeAndLoserDarakbangMemberIdIsNull(
+		List<BetEntity> betEntities = betRepository.findAllByBettingTimeGreaterThanEqualAndLoserDarakbangMemberIdIsNull(
 			LocalDateTime.now().withSecond(0).withNano(0));
 
 		//then

--- a/backend/src/test/java/mouda/backend/common/fixture/BetEntityFixture.java
+++ b/backend/src/test/java/mouda/backend/common/fixture/BetEntityFixture.java
@@ -43,7 +43,7 @@ public class BetEntityFixture {
 	public static BetEntity getBetEntity(long darakbangId, long moimerId, LocalDateTime bettingTime) {
 		return BetEntity.builder()
 			.title("테바바보")
-			.bettingTime(bettingTime.withSecond(0).withNano(0))
+			.bettingTime(bettingTime)
 			.darakbangId(darakbangId)
 			.moimerId(moimerId)
 			.build();

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -38,6 +38,7 @@ oauth:
 
 bet:
   schedule: "* * * * * *" # 테스트 스케줄러는 매초마다 동작
+  master: false
 
 aws:
   region:


### PR DESCRIPTION
## PR의 목적이 무엇인가요?

현재 매분 0초에 스케줄러가 돌면서 추첨시간과 동일한 뽑기에 대해 추첨하고 있습니다.

1. 추첨대상이 없음에도 불필요한 DB 접근
2. 기존에는 초 단위를 버림. → 사용자가 의도와 실제 추첨 시간에 오차 발생


## 설명

태스크 예약이 되어있지만 서버가 종료되는 경우 예약된 태스크는 유지되지 않습니다.
해당 문제를 해결하기 위해 서버를 시작하면 추후 추첨이 필요한 태스크에 대해 다시 예약을 진행합니다.
서버가 2대이기에 중복 예약을 방지할 필요가 있습니다.
재시작하는 시점에서는 하나의 서버(master)만 예약을 진행합니다.

## 질문 혹은 공유 사항 (Optional)

<!-- 필요 시 작성해 주세요. -->
